### PR TITLE
Add CORS header for the deck list

### DIFF
--- a/backend/api/deck.go
+++ b/backend/api/deck.go
@@ -74,6 +74,7 @@ func (a *API) getDeckHandler(c *gin.Context) {
 		result.WriteString("\n")
 	}
 
+	c.Writer.Header().Set("Access-Control-Allow-Origin", "*")
 	c.Data(200, "text/plain", []byte(result.String()))
 }
 


### PR DESCRIPTION
This allows third party web apps to fetch
the deck list.